### PR TITLE
coerce cassette filenames to string

### DIFF
--- a/src/vcr_clj/core.clj
+++ b/src/vcr_clj/core.clj
@@ -47,8 +47,8 @@
     (func)))
 
 (defn- cassette-file
-  [name]
-  (let [f (fs/file "cassettes" (str name ".clj"))]
+  [cassette-name]
+  (let [f (fs/file "cassettes" (str (name cassette-name) ".clj"))]
     (-> f fs/parent fs/mkdirs)
     f))
 


### PR DESCRIPTION
This patch lets us pass keywords for cassette filenames, and stringifies them when creating the output file.
