### PR TITLE
Empty body in a clj-http cassette throws exception

### DIFF
--- a/src/vcr_clj/cassettes/serialization.clj
+++ b/src/vcr_clj/cassettes/serialization.clj
@@ -74,7 +74,10 @@
   [hex-str]
   (-> hex-str
       .getBytes
-      b64/decode
+      ;; data.codec cannot roundtrip an empty string
+      ;; through a base64 encode/decode
+      ;; http://dev.clojure.org/jira/browse/DCODEC-4
+      (cond-> (seq hex-str) b64/decode)
       java.io.ByteArrayInputStream.
       serializablize-input-stream))
 

--- a/test/vcr_clj/test/cassettes/serialization.clj
+++ b/test/vcr_clj/test/cassettes/serialization.clj
@@ -1,0 +1,11 @@
+(ns vcr-clj.test.cassettes.serialization
+  (:require [clojure.test :refer :all]
+            [vcr-clj.cassettes.serialization :refer :all]))
+
+(deftest can-read-input-stream
+  (testing "simple base64 encoded string"
+    (let [istream (read-input-stream "aGVsbG8=")]
+      (is (= "hello" (slurp istream)))))
+  (testing "empty string"
+    (let [istream (read-input-stream "")]
+      (is (= "" (slurp istream))))))


### PR DESCRIPTION
Presently, if reading from a clj-http cassette recorded with an empty body:
```
:body #vcr-clj/input-stream ""
```
a ArrayIndexOutOfBoundsException is thrown.

I've implemented a fix along with a test case showing the issue. I'd like to create a more 'end-to-end' test that shows it within the vcr-clj.test.clj-http ns but was unable to do so in the short time I had.