### PR TITLE
Added check for edge case where byte string is empty.

### DIFF
--- a/src/vcr_clj/cassettes/serialization.clj
+++ b/src/vcr_clj/cassettes/serialization.clj
@@ -28,7 +28,9 @@
 
 (defn str->bytes
   [s]
-  (b64/decode (.getBytes s)))
+  (if (empty? s)
+    (.getBytes "")
+    (b64/decode (.getBytes s))))
 
 (defmethod print-method (type (byte-array 2))
   [ba ^java.io.Writer pw]

--- a/test/vcr_clj/test/cassettes/serialization.clj
+++ b/test/vcr_clj/test/cassettes/serialization.clj
@@ -1,6 +1,7 @@
 (ns vcr-clj.test.cassettes.serialization
   (:require [clojure.test :refer :all]
-            [vcr-clj.cassettes.serialization :refer :all]))
+            [vcr-clj.cassettes.serialization :refer :all])
+  (:import (java.util Arrays)))
 
 (deftest can-read-input-stream
   (testing "simple base64 encoded string"
@@ -9,3 +10,10 @@
   (testing "empty string"
     (let [istream (read-input-stream "")]
       (is (= "" (slurp istream))))))
+
+(deftest can-read-base64-bytes
+  (testing "Works with empty data"
+    (is (true? (Arrays/equals (.getBytes "") (str->bytes ""))))
+    )
+  (testing "Works with standard data"
+    (is (true? (Arrays/equals  (.getBytes "testing") (str->bytes "dGVzdGluZw=="))))))


### PR DESCRIPTION
This was an edge case I came across while testing DELETE calls - if the recorded response body is empty, an exception is thrown because it's decoding an invalid base64 string.
There are a couple of different ways to fix this, but I went for the simplest: an empty check in str->bytes.