### PR TITLE
Add support for namespaced keywords as cassette names

### DIFF
--- a/src/vcr_clj/cassettes.clj
+++ b/src/vcr_clj/cassettes.clj
@@ -4,12 +4,18 @@
             [fs.core :as fs]
             [vcr-clj.cassettes.serialization :refer [data-readers]]))
 
+(defn cassette-path [cassette-name]
+  (if (keyword? cassette-name)
+    (remove nil? ((juxt namespace name) cassette-name))
+    [(name cassette-name)]))
+
 (defn cassette-file
   "Returns the File object for a given cassette name. Ensures parent
    directories exist."
   [cassette-name]
-  (doto (fs/file "cassettes" (str (name cassette-name) ".clj"))
-    (-> fs/parent fs/mkdirs)))
+  (let [path (concat ["cassettes"] (cassette-path cassette-name) [".clj"])]
+    (doto (apply fs/file path)
+      (-> fs/parent fs/mkdirs))))
 
 (defn cassette-exists?
   [name]

--- a/src/vcr_clj/cassettes.clj
+++ b/src/vcr_clj/cassettes.clj
@@ -5,15 +5,16 @@
             [vcr-clj.cassettes.serialization :refer [data-readers]]))
 
 (defn cassette-path [cassette-name]
-  (if (keyword? cassette-name)
-    (remove nil? ((juxt namespace name) cassette-name))
-    [(name cassette-name)]))
+  (let [[name ns] (if (keyword? cassette-name)
+                    ((juxt name namespace) cassette-name)
+                    [(name cassette-name)])]
+    (remove nil? [ns (str name ".clj")])))
 
 (defn cassette-file
   "Returns the File object for a given cassette name. Ensures parent
    directories exist."
   [cassette-name]
-  (let [path (concat ["cassettes"] (cassette-path cassette-name) [".clj"])]
+  (let [path (cons "cassettes" (cassette-path cassette-name))]
     (doto (apply fs/file path)
       (-> fs/parent fs/mkdirs))))
 

--- a/test/vcr_clj/test/cassettes.clj
+++ b/test/vcr_clj/test/cassettes.clj
@@ -1,0 +1,9 @@
+(ns vcr-clj.test.cassettes
+  (:require [vcr-clj.cassettes :refer [cassette-path]]
+            [clojure.test :refer :all]))
+
+(deftest cassette-path-test
+  (are [input expected] (= (cassette-path input) expected)
+    "foobar" ["foobar"]
+    :foobar ["foobar"]
+    ::foobar ["vcr-clj.test.cassettes" "foobar"]))

--- a/test/vcr_clj/test/cassettes.clj
+++ b/test/vcr_clj/test/cassettes.clj
@@ -4,6 +4,6 @@
 
 (deftest cassette-path-test
   (are [input expected] (= (cassette-path input) expected)
-    "foobar" ["foobar"]
-    :foobar ["foobar"]
-    ::foobar ["vcr-clj.test.cassettes" "foobar"]))
+    "foobar" ["foobar.clj"]
+    :foobar ["foobar.clj"]
+    ::foobar ["vcr-clj.test.cassettes" "foobar.clj"]))


### PR DESCRIPTION
This would be useful in one of our projects, and we reached the conclusion that multiple not-as-nested directories is better than less top-level ones with deeper nesting.