### PR TITLE
Recording new episodes with existing cassettes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,10 @@ Each var that is recorded can be customized with options:
                   fn; if it returns falsy, the call will be passed to
                   through to the original function both during recording
                   and playback.
-
-## TODO
-
-* Add a better way to re-record than deleting cassette files.
-  Maybe an environment variable?
+- `:record-new-episodes?`:
+                  a boolean indicating if an existing cassette should be
+                  updated with calls that were not previously recorded.
+                  defaults to false.
 
 ## License
 

--- a/src/vcr_clj/cassettes.clj
+++ b/src/vcr_clj/cassettes.clj
@@ -28,8 +28,15 @@
     (binding [*out* writer]
       (prn cassette))))
 
+(defn- reattach-http-meta
+  [cassette]
+  (let [set-http-meta #(vary-meta % assoc :type :vcr-clj.clj-http/serializable-http-request)
+        update-episode #(update % :return set-http-meta)]
+    (update cassette :calls #(mapv update-episode %))))
+
 ;; TODO: use clojure.edn?
 (defn read-cassette
   [name]
-  (with-open [r (java.io.PushbackReader. (io/reader (cassette-file name)))]
-    (edn/read {:readers data-readers} r)))
+  (let [cassette (with-open [r (java.io.PushbackReader. (io/reader (cassette-file name)))]
+                   (edn/read {:readers data-readers} r))]
+    (reattach-http-meta cassette)))

--- a/test/vcr_clj/test/clj_http.clj
+++ b/test/vcr_clj/test/clj_http.clj
@@ -123,3 +123,21 @@
       (is (= "bar" (get "/foo")))))
   (with-cassette :whale
     (is (= "bar" (get "/foo")))))
+
+(defn time-server [&args]
+  {:status 200
+   :body (str (System/currentTimeMillis))
+   :headers {}})
+
+
+(deftest recording-new-http-episodes
+  (with-jetty-server time-server
+    (with-local-vars [result-with-a nil
+                      result-with-b nil]
+      (with-cassette :recording-new-episodes
+        (var-set result-with-a (get "/a")))
+      (with-cassette :recording-new-episodes {:record-new-episodes? true}
+        (var-set result-with-b (get "/b")))
+      (with-cassette :recording-new-episodes
+        (is (= (get "/a") @result-with-a))
+        (is (= (get "/b") @result-with-b))))))

--- a/test/vcr_clj/test/core.clj
+++ b/test/vcr_clj/test/core.clj
@@ -110,3 +110,18 @@
       (is (= 42 (self-caller 41))))
     (is (empty? (calls self-caller))
         "the recorded call does not result in any self-calls")))
+
+(defn current-time [& args]
+  "Accepts any arguments and returns the current time"
+  (System/currentTimeMillis))
+
+(deftest recording-new-episodes
+  (with-local-vars [result-with-a nil
+                    result-with-b nil]
+    (with-cassette :recording-new-episodes [{:var #'current-time}] (var-set result-with-a (current-time :a)))
+    (with-cassette :recording-new-episodes [{:var #'current-time :record-new-episodes? true}]
+      (var-set result-with-b (current-time :b)))
+    (with-cassette :recording-new-episodes [{:var #'current-time}]
+      (is (= (current-time :a) @result-with-a))
+      (is (= (current-time :b) @result-with-b)))))
+


### PR DESCRIPTION
Hello! My team has been using vcr-clj to test a number of things and it's often a little laborious for us to re-record cassettes entire when new calls need to be added. So, I added a new flag to `with-cassette` that allows new calls to be added to existing cassettes when set. Let me know what you think!