### PR TITLE
Use *data-readers* when deserializing

### DIFF
--- a/src/vcr_clj/cassettes.clj
+++ b/src/vcr_clj/cassettes.clj
@@ -32,4 +32,4 @@
 (defn read-cassette
   [name]
   (with-open [r (java.io.PushbackReader. (io/reader (cassette-file name)))]
-    (edn/read {:readers data-readers} r)))
+    (edn/read {:readers (merge data-readers *data-readers*)} r)))

--- a/test/vcr_clj/test/core.clj
+++ b/test/vcr_clj/test/core.clj
@@ -133,3 +133,23 @@
           (.join))
         (is (= 2 (count (calls increment))))
         (is (= 100 @p))))))
+
+;; https://github.com/gfredericks/vcr-clj/issues/11
+
+(deftype Foo [x])
+
+(defmethod print-method Foo
+  [foo pw]
+  (.write pw "#foo ")
+  (print-method (.x foo) pw))
+
+(defn foo-maker
+  [x]
+  (Foo. x))
+
+(deftest custom-serializations
+  (binding [*data-readers* (assoc *data-readers*
+                                  'foo (fn [x] (Foo. x)))]
+    (dotimes [_ 2]
+      (with-cassette :foobles [{:var #'foo-maker}]
+        (= 42 (.x (foo-maker 42)))))))


### PR DESCRIPTION
This should allow users to supply data readers if they have types that
serialize with custom tags.

This is a proposed solution for #11.