### PR TITLE
bypass fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Each var that is recorded can be customized with options:
   function. This can be useful for ensuring serializability. The transformed
   return value ought to be equivalent to the original return value for the
   purpose of the code under test. The default is `clojure.core/identity`.
+- `:bypass-fn`: A function, which called while recording/playback with recorded
+  function result as argument.
 
 ## TODO
 

--- a/test/vcr_clj/test/core.clj
+++ b/test/vcr_clj/test/core.clj
@@ -155,3 +155,18 @@
           (.join))
         (is (= 2 (count (calls increment))))
         (is (= 100 @p))))))
+
+(defn some-bypass-fn [result]
+  (is (= 5 result))
+  result)
+
+(deftest bypass-test
+  (with-spy [plus some-bypass-fn]
+    (with-cassette :my [{:var #'plus :bypass-fn some-bypass-fn}]
+      (is (= 5 (plus 2 3)))
+      (is (= 1 (count (calls plus))))
+      (is (= 1 (count (calls some-bypass-fn)))))
+    (with-cassette :my [{:var #'plus :bypass-fn some-bypass-fn}]
+      (is (= 5 (plus 2 3)))
+      (is (= 1 (count (calls plus))))
+      (is (= 2 (count (calls some-bypass-fn)))))))


### PR DESCRIPTION
Hi, this is a bypass function implementation. My use case is open clj-http request results in browser for manual verification.