### PR TITLE
Serialisation Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ vcr-clj uses [Puget](https://github.com/greglook/puget) for storing cassettes
 on disk. The `:serialization` cassette key allows clients to customize the
 default configuration. The options available are:
 
-- `:print-handlers`: a function that replaces the
+- `:print-handlers`: a function that takes precedence over the
 [built-in function](https://github.com/gfredericks/vcr-clj/blob/e8efe21de72e001e846aacd241f8ae2aaacb4f55/src/vcr_clj/cassettes/serialization.clj#L101)
 for converting the cassette output to serializable data. See
 [Puget's documentation](https://github.com/greglook/puget#type-extensions) for
@@ -139,13 +139,11 @@ using the default base64 encoding.
   "Print handler for vcr-clj library. Enables support of additional object
   instances alongside vcr-clj defaults."
   [cls]
-  (if (isa? cls byte-array-class)
+  (when (isa? cls byte-array-class)
     (printer/tagged-handler
       'my.project/printable-bytes
       (fn [data]
-        (vcr-ser/split-bytes data 75)))
-
-    (vcr-ser/default-print-handlers cls)))
+        (vcr-ser/split-bytes data 75)))))
 
 (deftest here-is-my-bytes-test
   (with-cassette {:name :testaroo

--- a/README.md
+++ b/README.md
@@ -95,6 +95,67 @@ Each var that is recorded can be customized with options:
   return value ought to be equivalent to the original return value for the
   purpose of the code under test. The default is `clojure.core/identity`.
 
+### Cassette Customization
+
+Instead of invoking `with-cassette` with a name, you may invoke it with a map
+defining additional cassette data:
+
+- `:name`: the only required key in the map, this defines the name of the
+cassette as previously described.
+- `:serialization`: an optional map defining settings for controlling how
+the cassette is serialized and deserialized.
+
+#### De/serialization
+
+vcr-clj uses [Puget](https://github.com/greglook/puget) for storing cassettes
+on disk. The `:serialization` cassette key allows clients to customize the
+default configuration. The options available are:
+
+- `:print-handlers`: a function that replaces the
+[built-in function](https://github.com/gfredericks/vcr-clj/blob/e8efe21de72e001e846aacd241f8ae2aaacb4f55/src/vcr_clj/cassettes/serialization.clj#L101)
+for converting the cassette output to serializable data. See
+[Puget's documentation](https://github.com/greglook/puget#type-extensions) for
+more details
+- `:data-readers`: map that merges over
+[the defaults](https://github.com/gfredericks/vcr-clj/blob/e8efe21de72e001e846aacd241f8ae2aaacb4f55/src/vcr_clj/cassettes/serialization.clj#L96).
+This mapping determines how specific symbols in the saved cassette are
+converted back to the original data.
+
+The following example prints the raw bytes from a byte array instead of
+using the default base64 encoding.
+
+``` clojure
+(ns my.project-test
+  (:require [clojure.test :refer :all]
+            [puget.printer :as printer]
+            [vcr-clj.cassettes.serialization :as vcr-ser]
+            [vcr-clj.core :as vcr]))
+
+(def byte-array-class
+  "Standard Java class for byte arrays"
+  (class (byte-array 0)))
+
+(defn extended-print-handlers
+  "Print handler for vcr-clj library. Enables support of additional object
+  instances alongside vcr-clj defaults."
+  [cls]
+  (if (isa? cls byte-array-class)
+    (printer/tagged-handler
+      'my.project/printable-bytes
+      (fn [data]
+        (vcr-ser/split-bytes data 75)))
+
+    (vcr-ser/default-print-handlers cls)))
+
+(deftest here-is-my-bytes-test
+  (with-cassette {:name :testaroo
+                  :serialization {:print-handlers extended-print-handlers
+                                  :data-readers {'my.project/printable-bytes (comp (fn [string] (.getBytes string))
+                                                                                   vcr-ser/maybe-join)}}}
+    ... do some testy things ...
+    ... that will return byte arrays ...))
+```
+
 ## TODO
 
 * Add a better way to re-record than deleting cassette files.

--- a/project.clj
+++ b/project.clj
@@ -36,10 +36,10 @@
              "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-112" "test,"
              "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-101" "test,"
              "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-091" "test,"
-             "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-077" "test,"
+             "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-077" "test,"]
              ;; 053 fails currently, don't feel like investigating
              ;; "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-053" "test"
-             ]
+
             "ci"
             ["do"
              "test-all-clj-https,"

--- a/src/vcr_clj/cassettes.clj
+++ b/src/vcr_clj/cassettes.clj
@@ -34,12 +34,13 @@
   (-> name cassette-file fs/exists?))
 
 (defn write-cassette
-  [name cassette]
+  [name cassette & [opts]]
   (with-open [writer (-> name cassette-file io/writer)]
     (binding [*out* writer]
-      (serialization/print cassette))))
+      (serialization/print cassette opts))))
 
 (defn read-cassette
-  [name]
+  [name & [{:keys [data-readers]
+            :or {data-readers {}}}]]
   (with-open [r (java.io.PushbackReader. (io/reader (cassette-file name)))]
-    (edn/read {:readers serialization/data-readers} r)))
+    (edn/read {:readers (merge serialization/data-readers data-readers)} r)))

--- a/src/vcr_clj/cassettes/serialization.clj
+++ b/src/vcr_clj/cassettes/serialization.clj
@@ -133,7 +133,7 @@
 
 (defn print
   [cassette & [{:keys [print-handlers]
-                :or {print-handlers (fn [& _] false)}}]]
+                :or {print-handlers (constantly false)}}]]
   (let [merged-print-handlers (some-fn print-handlers default-print-handlers)]
     (printer/pprint cassette (merge puget-options
                                     {:print-handlers merged-print-handlers}))))

--- a/src/vcr_clj/cassettes/serialization.clj
+++ b/src/vcr_clj/cassettes/serialization.clj
@@ -27,8 +27,8 @@
              :else
              (throw (ex-info
                      "Cannot parse #vcr-clj/clj-http-header-map tag in cassette (map expected)"
-                     {:value m}))
-             )))
+                     {:value m})))))
+
        true
        (catch Throwable t
          false)))
@@ -98,7 +98,7 @@
    'vcr-clj/input-stream        (comp read-input-stream maybe-join)
    'vcr-clj/clj-http-header-map read-clj-http-header-map})
 
-(def print-handlers
+(def default-print-handlers
   (some-fn
    (cond-> {(class (byte-array 0))
             (printer/tagged-handler
@@ -126,12 +126,13 @@
    :map-delimiter      ",",
    :print-color        false,
    :print-fallback     :print,
-   :print-handlers     print-handlers
    :print-meta         false,
    :sort-keys          true,
    :strict             false,
    :width              80})
 
 (defn print
-  [cassette]
-  (printer/pprint cassette puget-options))
+  [cassette & [{:keys [print-handlers]
+                :or {print-handlers default-print-handlers}}]]
+  (printer/pprint cassette (merge puget-options
+                                  {:print-handlers print-handlers})))

--- a/src/vcr_clj/cassettes/serialization.clj
+++ b/src/vcr_clj/cassettes/serialization.clj
@@ -133,6 +133,7 @@
 
 (defn print
   [cassette & [{:keys [print-handlers]
-                :or {print-handlers default-print-handlers}}]]
-  (printer/pprint cassette (merge puget-options
-                                  {:print-handlers print-handlers})))
+                :or {print-handlers (fn [& _] false)}}]]
+  (let [merged-print-handlers (some-fn print-handlers default-print-handlers)]
+    (printer/pprint cassette (merge puget-options
+                                    {:print-handlers merged-print-handlers}))))

--- a/src/vcr_clj/core.clj
+++ b/src/vcr_clj/core.clj
@@ -121,6 +121,8 @@
 (defn with-cassette-fn*
   [{:keys [name serialization] :as cassette-data} specs func]
   (let [cassette-name (or name cassette-data)]
+    (when-not (or (string? cassette-name) (keyword? cassette-name))
+      (throw (ex-info "No valid cassette name given" {:invalid cassette-name})))
     (if (cassette-exists? cassette-name)
       (do
         (println' "Running test with existing" cassette-name "cassette...")

--- a/test/vcr_clj/test/core.clj
+++ b/test/vcr_clj/test/core.clj
@@ -3,6 +3,8 @@
   (:require [bond.james :refer [calls with-spy]]
             [clj-http.client :as client]
             [clojure.test :refer :all]
+            [puget.printer :as printer]
+            [vcr-clj.cassettes.serialization :as serialization]
             [vcr-clj.cassettes :as cassettes]
             [vcr-clj.core :refer [with-cassette]]
             [vcr-clj.test.helpers :as help]))
@@ -13,6 +15,8 @@
 (defn plus [a b] (+ a b))
 (defn increment [x] (inc x))
 (defn put-foo [m v] (assoc m :foo v))
+(defn java-obj [val] (proxy [java.io.InputStream] []
+                       (read ([] val))))
 
 (deftest basic-test
   (with-spy [plus]
@@ -108,6 +112,25 @@
       (is (= [{} 42]
              (:args (first (calls put-foo)))))
       (is (-> (calls put-foo) first :args first meta :arg-transformer)))))
+
+(defn test-print-handlers
+  [cls]
+  (if (isa? cls java.io.InputStream)
+    (printer/tagged-handler
+      'vcr/inputstream
+      (fn [stream]
+        (.read stream)))
+
+    (serialization/default-print-handlers cls)))
+
+(deftest cassette-data-test
+  (with-spy [java-obj]
+    (with-cassette
+      {:name :boom
+       :serialization {:print-handlers test-print-handlers}}
+      [{:var #'java-obj}]
+      (is (instance? java.io.InputStream (java-obj 3)))
+      (is (= 1 (count (calls java-obj)))))))
 
 (defn self-caller
   "Multi-arity function that calls itself when called with one argument"

--- a/test/vcr_clj/test/core.clj
+++ b/test/vcr_clj/test/core.clj
@@ -124,13 +124,15 @@
     (serialization/default-print-handlers cls)))
 
 (deftest cassette-data-test
-  (with-spy [java-obj]
+  (with-spy [java-obj serialization/print]
     (with-cassette
       {:name :boom
        :serialization {:print-handlers test-print-handlers}}
       [{:var #'java-obj}]
       (is (instance? java.io.InputStream (java-obj 3)))
-      (is (= 1 (count (calls java-obj)))))))
+      (is (= 1 (count (calls java-obj)))))
+    (is (= {:print-handlers test-print-handlers}
+           (-> (calls serialization/print) first :args second)))))
 
 (defn self-caller
   "Multi-arity function that calls itself when called with one argument"

--- a/test/vcr_clj/test/core.clj
+++ b/test/vcr_clj/test/core.clj
@@ -33,6 +33,12 @@
       (is (thrown? clojure.lang.ExceptionInfo
             (plus 3 4))))))
 
+(deftest name-validation-test
+  (is (thrown? clojure.lang.ExceptionInfo
+        (with-cassette {:bame "typo-in-name"} [{:var #'plus}])))
+  (is (thrown? clojure.lang.ExceptionInfo
+        (with-cassette {:name 'vcr-clj.core/symbol-not-allowed} [{:var #'plus}]))))
+
 (deftest two-vars-test
   (with-spy [plus increment]
     (is (empty? (calls plus)))


### PR DESCRIPTION
I've added optional arguments to support extending or modifying the default behaviour of cassette serialisation. This was to allow me to change the default behaviour of byte array serialisation, which is safe by default but means re-recording the cassette each time even one minor bit of the response changes. Changing it to simply save the stringified version makes the cassette easy to modify manually in those cases.
Also, I want to add correct de/serialisation of exceptions for some tests in future and this will allow me to do so.

I've also added a new macro that exposes these serialisation arguments as a separate required argument. I haven't documented this in the README as yet because I'm not sure if this is what you want to do for exposing these options in the public interface. My own tests don't use this but use a more custom macro that isn't really suitable here.