### PR TITLE
Add CircleCI 2.0 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+# Clojure CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-clojure/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/clojure:lein-2.9.1
+
+    working_directory: ~/repo
+
+    environment:
+      LEIN_ROOT: "true"
+      JVM_OPTS: -Xmx3200m
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "project.clj" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: lein deps
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies-{{ checksum "project.clj" }}
+
+      # run tests!
+      - run: lein test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - v1-dependencies-
 
-      - run: lein deps
+      - run: lein ci-deps
 
       - save_cache:
           paths:
@@ -32,4 +32,4 @@ jobs:
           key: v1-dependencies-{{ checksum "project.clj" }}
 
       # run tests!
-      - run: lein test
+      - run: lein ci

--- a/project.clj
+++ b/project.clj
@@ -40,6 +40,25 @@
              ;; 053 fails currently, don't feel like investigating
              ;; "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-053" "test"
              ]
+            "retrieve-all-profile-deps"
+            ^{:doc "Retrieve all deps required by all profiles"}
+            ["do"
+             "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-390" "deps,"
+             "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-370" "deps,"
+             "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-341" "deps,"
+             "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-230" "deps,"
+             "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-112" "deps,"
+             "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-101" "deps,"
+             "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-091" "deps,"
+             "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-077" "deps,"
+             "clean," "with-profile" "-dev,+test-deps-without-clj-http,+clj-http-053" "deps"
+             ]
+            "ci-deps"
+            ["do"
+             "retrieve-all-profile-deps,"
+             "with-profile" "-clojure-17,+clojure-18" "retrieve-all-profile-deps,"
+             "with-profile" "-clojure-17,+clojure-19" "retrieve-all-profile-deps"
+             ]
             "ci"
             ["do"
              "test-all-clj-https,"


### PR DESCRIPTION
I noticed that your project was still using the old CircleCI build engine, which was disabled several months ago. This PR updates the CircleCI build configuration to use their new build engine.