### PR TITLE
Fix some reflection warnings

### DIFF
--- a/src/vcr_clj/cassettes/serialization.clj
+++ b/src/vcr_clj/cassettes/serialization.clj
@@ -33,7 +33,7 @@
        (catch Throwable t
          false)))
 
-(defn split-bytes [^bytes ba maxl]
+(defn split-bytes [^bytes ba ^long maxl]
   (let [l (alength ba)]
     (persistent!
       (loop
@@ -46,7 +46,7 @@
             (conj! acc (String. ba start-index (min maxl (- l start-index))))))))))
 
 (defn str->bytes
-  [s]
+  [^String s]
   (if (empty? s)
     (.getBytes "")
     (b64/decode (.getBytes s))))
@@ -80,7 +80,7 @@
       (meta [] {:type ::serializable-input-stream}))))
 
 (defn read-input-stream
-  [hex-str]
+  [^String hex-str]
   (-> hex-str
       .getBytes
       ;; data.codec cannot roundtrip an empty string

--- a/test/vcr_clj/test/cassettes/serialization.clj
+++ b/test/vcr_clj/test/cassettes/serialization.clj
@@ -14,9 +14,9 @@
 
 (deftest can-read-base64-bytes
   (testing "Works with empty data"
-    (is (true? (Arrays/equals (.getBytes "") (serialization/str->bytes "")))))
+    (is (true? (Arrays/equals (.getBytes "") ^bytes (serialization/str->bytes "")))))
   (testing "Works with standard data"
-    (is (true? (Arrays/equals  (.getBytes "testing") (serialization/str->bytes "dGVzdGluZw=="))))))
+    (is (true? (Arrays/equals  (.getBytes "testing") ^bytes (serialization/str->bytes "dGVzdGluZw=="))))))
 
 (deftest can-read-old-header-map-format
   (when-let [c (try


### PR DESCRIPTION
There is still one remaining, but that's in a third-party lib that isn't being updated anymore:

```
Reflection warning, /Users/ikoszo/.m2/repository/me/raynes/fs/1.4.6/fs-1.4.6.jar!/me/raynes/fs.clj:517:42 - reference to field getName can't be resolved.
```