### PR TITLE
Replace me.raynes/fs with clj-commons/fs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject com.gfredericks/vcr-clj "0.4.22-SNAPSHOT"
   :description "HTTP recording/playback for Clojure"
   :dependencies [[org.clojure/data.codec "0.1.0"]
-                 [me.raynes/fs "1.4.6"]
+                 [clj-commons/fs "1.6.309"]
                  [mvxcvi/puget "1.1.2"]]
   :deploy-repositories [["releases" :clojars]]
   :profiles {;; I'm not sure how it happened but the 0.4.20 release


### PR DESCRIPTION
The `me.raynes/fs` library is no longer maintained and `clj-commons/fs` is the maintained version of the same codebase.

Dependency changes:
- me.raynes/fs 1.4.6 -> clj-commons/fs 1.6.309
- org.apache.commons/commons-compress 1.8 -> 1.21
- org.tukaani/xz 1.5 -> 1.8

The prompt for this change is CVE-2021-36090 which affects `commons-compress` but should not actually affect `vcr-clj` since it does not use `me.raynes.fs.compression`. This change merely prevents `vcr-clj` from triggering false positives in vulnerability management systems.